### PR TITLE
Correct Postgres volume

### DIFF
--- a/kube/deployments/postgres_deploy.yaml
+++ b/kube/deployments/postgres_deploy.yaml
@@ -39,7 +39,7 @@ spec:
         - name: POSTGRES_DB
           value: "rails-kube-demo_production"
         - name: PGDATA
-          value: "/var/lib/postgresql/data"
+          value: "/var/lib/postgresql/data/pgdata"
         ports:
         - containerPort: 5432
         volumeMounts:


### PR DESCRIPTION
Use the combination of volume mount path and PGDATA as specified in the documentation of the Docker image to prevent loss of data on container recreation.

For reference: https://hub.docker.com/_/postgres under PGDATA.