### PR TITLE
update ruby and bundler versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.4-alpine3.10
+FROM ruby:2.7-alpine3.10
 
 RUN apk --update add nodejs netcat-openbsd postgresql-dev
 RUN apk --update add --virtual build-dependencies make g++
@@ -10,6 +10,7 @@ WORKDIR /myapp
 ADD Gemfile /myapp/Gemfile
 ADD Gemfile.lock /myapp/Gemfile.lock
 
+RUN gem install bundler -v '1.17.2'
 RUN bundle install
 RUN apk del build-dependencies && rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
Docker build shows the error followed by a need to install compatible `bundler -v '1.17.2'` to Gemfile.lock
~~~
nokogiri-1.14.3-x86_64-linux requires ruby version >= 2.7, < 3.3.dev, which is
incompatible with the current version, ruby 2.6.4p104
The command '/bin/sh -c bundle install' returned a non-zero code: 5
ERROR: Service 'setup' failed to build : Build failed
~~~